### PR TITLE
支持openai代理；容器化

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,1 +1,1 @@
-apiBase = "https://api.openai.com/v1"
+api_base="https://api.openai.com/v1"

--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,0 +1,1 @@
+apiBase = "https://api.openai.com/v1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /opt/chatgpt-ai
 
 ADD ./ ./
 
+ENV OPENAI_API_KEY=sk-XXXXXXXXX
+ENV OPENAI_API_BASE=https://openaiproxy.xxx.com/v1
+
 RUN pip install --no-cache-dir --upgrade -r requirements.txt --timeout 1000
 
-# 下面这条命令，通过nginx做反向代理可以生效
-ENTRYPOINT  streamlit run app.py --server.port=8501 --server.enableCORS false --server.enableXsrfProtection false
+RUN chmod a+x /opt/chatgpt-ai/entrypoint.sh
+
+ENTRYPOINT  /opt/chatgpt-ai/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /opt/chatgpt-ai
 
 ADD ./ ./
 
-ENV OPENAI_API_KEY=sk-XXXXXXXXX
-ENV OPENAI_API_BASE=https://openaiproxy.xxx.com/v1
+# ENV OPENAI_API_KEY=sk-XXXXXXXXX
+# ENV OPENAI_API_BASE=https://api.openai.com/v1
 
 RUN pip install --no-cache-dir --upgrade -r requirements.txt --timeout 1000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10
+
+WORKDIR /opt/chatgpt-ai
+
+ADD ./ ./
+
+RUN pip install --no-cache-dir --upgrade -r requirements.txt --timeout 1000
+
+# 下面这条命令，通过nginx做反向代理可以生效
+ENTRYPOINT  streamlit run app.py --server.port=8501 --server.enableCORS false --server.enableXsrfProtection false

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 也可以在部署完成后再进行配置。
 
 ## 本地部署
-本地部署需要科学上网。
+本地部署需要科学上网，或者借助项目[openai-forward](https://github.com/beidongjiedeguang/openai-forward)代理访问openai接口
 1. 建立虚拟环境（建议）
 
 2. 克隆项目（也可以手动下载到本地）
@@ -43,9 +43,10 @@ git clone https://github.com/PierXuY/ChatGPT-Assistant.git
 pip install -r requirements.txt
 ```
 
-4. 设置API Key   
+4. 设置API Key;设置API Base（可选）
 
 - 在 `.streamlit/secrets.toml`文件中写入`apikey = "Your Openai Key"`
+- 在 `.streamlit/secrets.toml`文件中可修改`apiBase = "https://openaiproxy.xxxx.com/v1"` （可选）
 
 5. 启动应用
 ```bash
@@ -62,3 +63,4 @@ streamlit run app.py
 - 最早是基于[shan-mx/ChatGPT_Streamlit](https://github.com/shan-mx/ChatGPT_Streamlit)项目进行的改造，感谢。
 - 预设的[上下文功能](https://github.com/PierXuY/ChatGPT-Assistant/blob/main/set_context.py)参考自[binary-husky/chatgpt_academic](https://github.com/binary-husky/chatgpt_academic)项目和[f/awesome-chatgpt-prompts](https://github.com/f/awesome-chatgpt-prompts)项目，感谢。
 - 语音交互功能参考了项目[talk-to-chatgpt](https://github.com/C-Nedelcu/talk-to-chatgpt)和[Voice Control for ChatGPT](https://chrome.google.com/webstore/detail/voice-control-for-chatgpt/eollffkcakegifhacjnlnegohfdlidhn)的实现，感谢。
+- 免科学上网功能可以借助项目[openai-forward](https://github.com/beidongjiedeguang/openai-forward)，感谢。

--- a/app.py
+++ b/app.py
@@ -224,6 +224,9 @@ with tap_model:
     st.text_input("OpenAI API Key (可选)", type='password', key='apikey_input', label_visibility='collapsed')
     st.caption(
         "此Key仅在当前网页有效，且优先级高于Secrets中的配置，仅自己可用，他人无法共享。[官网获取](https://platform.openai.com/account/api-keys)")
+    st.markdown("OpenAI Base (可选)")
+    st.text_input("OpenAI Base (可选)", key='apiBase_input', label_visibility='collapsed')
+    st.caption("此Base设置参考 https://github.com/beidongjiedeguang/openai-forward")
 
     st.markdown("包含对话次数：")
     st.slider(
@@ -358,6 +361,14 @@ if st.session_state['user_input_content'] != '':
             # 注：当st.secrets中配置apikey后将会留存聊天记录，即使未使用此apikey
             else:
                 openai.api_key = st.secrets["apikey"]
+            if apiBase := st.session_state['apiBase_input']:
+                openai.api_base = apiBase
+            # 配置临时apiBase，此时不会留存聊天记录，适合公开使用
+            elif "apiBase_tem" in st.secrets:
+                openai.api_base = st.secrets["apiBase_tem"]
+            # 注：当st.secrets中配置apikey后将会留存聊天记录，即使未使用此apikey
+            else:
+                openai.api_base = st.secrets["apiBase"]
             r = openai.ChatCompletion.create(model=st.session_state["select_model"], messages=history_need_input,
                                              stream=True,
                                              **paras_need_input)

--- a/app.py
+++ b/app.py
@@ -225,7 +225,7 @@ with tap_model:
     st.caption(
         "此Key仅在当前网页有效，且优先级高于Secrets中的配置，仅自己可用，他人无法共享。[官网获取](https://platform.openai.com/account/api-keys)")
     st.markdown("OpenAI Base (可选)")
-    st.text_input("OpenAI Base (可选)", key='apiBase_input', label_visibility='collapsed')
+    st.text_input("OpenAI Base (可选)", key='api_base_input', label_visibility='collapsed')
     st.caption("此Base设置参考 https://github.com/beidongjiedeguang/openai-forward")
 
     st.markdown("包含对话次数：")
@@ -361,14 +361,12 @@ if st.session_state['user_input_content'] != '':
             # 注：当st.secrets中配置apikey后将会留存聊天记录，即使未使用此apikey
             else:
                 openai.api_key = st.secrets["apikey"]
-            if apiBase := st.session_state['apiBase_input']:
-                openai.api_base = apiBase
-            # 配置临时apiBase，此时不会留存聊天记录，适合公开使用
-            elif "apiBase_tem" in st.secrets:
-                openai.api_base = st.secrets["apiBase_tem"]
-            # 注：当st.secrets中配置apikey后将会留存聊天记录，即使未使用此apikey
+            if api_base := st.session_state['api_base_input']:
+                openai.api_base = api_base
+            elif "api_base_tem" in st.secrets:
+                openai.api_base = st.secrets["api_base_tem"]
             else:
-                openai.api_base = st.secrets["apiBase"]
+                openai.api_base = st.secrets["api_base"]
             r = openai.ChatCompletion.create(model=st.session_state["select_model"], messages=history_need_input,
                                              stream=True,
                                              **paras_need_input)

--- a/docker.groovy
+++ b/docker.groovy
@@ -15,7 +15,7 @@ node {
     }
     stage('dockerFile') {
         sh 'rm -rf code && mkdir code'
-        sh 'cp ./*.py ./code && cp Dockerfile ./code && cp requirements.txt ./code'
+        sh 'cp *.py ./code && cp Dockerfile ./code && cp requirements.txt ./code && cp *.sh ./code'
         sh 'cp -r ./text_toolkit ./voice_toolkit ./.streamlit ./code'
         dir('code'){
             stash 'code'

--- a/docker.groovy
+++ b/docker.groovy
@@ -1,0 +1,57 @@
+parameters {
+    string(
+            description: '输入版本号',
+            name: 'version',
+            defaultValue: '1.0'
+    )
+}
+
+def version = "${params.version}"
+
+node {
+    stage('git chekout') {
+        git branch: 'main',
+                url: 'https://github.com/fastjrun-ml/ChatGPT-Assistant.git'
+    }
+    stage('dockerFile') {
+        sh 'rm -rf code && mkdir code'
+        sh 'cp ./*.py ./code && cp Dockerfile ./code && cp requirements.txt ./code'
+        sh 'cp -r ./text_toolkit ./voice_toolkit ./.streamlit ./code'
+        dir('code'){
+            stash 'code'
+        }
+    }
+    stage('parallel docker build') {
+        parallel (
+                'docker build && push arm64': {
+                    node('arm64') {
+                        dir('workdir'){
+                            unstash 'code'
+                        }
+                        sh 'cd workdir && docker build . -t pi4k8s/chatgpt-ai:$version-arm64'
+                        sh 'docker push pi4k8s/chatgpt-ai:$version-arm64'
+                    }
+                },
+                'docker build && push amd64': {
+                    node('amd64') {
+                        dir('workdir'){
+                            unstash 'code'
+                        }
+                        sh 'cd workdir && docker build . -t pi4k8s/chatgpt-ai:$version-amd64'
+                        sh 'docker push pi4k8s/chatgpt-ai:$version-amd64'
+                    }
+                }
+        )
+    }
+    stage('manifest'){
+        try {
+            sh "docker manifest rm pi4k8s/chatgpt-ai:$version"
+        }catch(exc){
+            echo "some thing wrong"
+        }
+        sh "docker manifest create pi4k8s/chatgpt-ai:$version pi4k8s/chatgpt-ai:$version-amd64 pi4k8s/chatgpt-ai:$version-arm64"
+        sh "docker manifest annotate pi4k8s/chatgpt-ai:$version pi4k8s/chatgpt-ai:$version-amd64 --os linux --arch amd64"
+        sh "docker manifest annotate pi4k8s/chatgpt-ai:$version pi4k8s/chatgpt-ai:$version-arm64 --os linux --arch arm64"
+        sh "docker manifest push pi4k8s/chatgpt-ai:$version"
+    }
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
-sed -i "1i\apikey = \"$OPENAI_API_KEY\"" ./.streamlit/secrets.toml &
-sed -i "s#^api_base.*#api_base = \"$OPENAI_API_BASE\"#" ./.streamlit/secrets.toml &
+if [ -n "$OPENAI_API_KEY" ]; then
+    sed -i "1i\apikey = \"$OPENAI_API_KEY\"" ./.streamlit/secrets.toml
+fi
+if [ -n "$OPENAI_API_BASE" ]; then
+    sed -i "s#^api_base.*#api_base = \"$OPENAI_API_BASE\"#" ./.streamlit/secrets.toml
+fi
 streamlit run app.py --server.port=8501 --server.enableCORS false --server.enableXsrfProtection false
-
-sed -i "s#^apiBase.*#api_base = \"$OPENAI_API_BASE\"#" ./.streamlit/secrets.toml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
-sed -i "1i\apiKey = $OPENAI_API_KEY" ./.streamlit/secrets.toml &
-sed -i "s#^apiBase.*#apiBase = $OPENAI_API_BASE#" ./.streamlit/secrets.toml &
+sed -i "1i\apikey = \"$OPENAI_API_KEY\"" ./.streamlit/secrets.toml &
+sed -i "s#^api_base.*#api_base = \"$OPENAI_API_BASE\"#" ./.streamlit/secrets.toml &
 streamlit run app.py --server.port=8501 --server.enableCORS false --server.enableXsrfProtection false
+
+sed -i "s#^apiBase.*#api_base = \"$OPENAI_API_BASE\"#" ./.streamlit/secrets.toml

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+sed -i "1i\apiKey = $OPENAI_API_KEY" ./.streamlit/secrets.toml &
+sed -i "s#^apiBase.*#apiBase = $OPENAI_API_BASE#" ./.streamlit/secrets.toml &
+streamlit run app.py --server.port=8501 --server.enableCORS false --server.enableXsrfProtection false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,15 @@
 if [ -n "$OPENAI_API_KEY" ]; then
-    sed -i "1i\apikey = \"$OPENAI_API_KEY\"" ./.streamlit/secrets.toml
+    if grep -q "apikey" "./.streamlit/secrets.toml"; then
+        sed -i "s#^apikey.*#apikey = \"$OPENAI_API_KEY\"#" ./.streamlit/secrets.toml
+    else
+        sed -i "1i\apikey = \"$OPENAI_API_KEY\"" ./.streamlit/secrets.toml
+    fi
 fi
 if [ -n "$OPENAI_API_BASE" ]; then
+    if grep -q "api_base" "./.streamlit/secrets.toml"; then
     sed -i "s#^api_base.*#api_base = \"$OPENAI_API_BASE\"#" ./.streamlit/secrets.toml
+    else
+        sed -i "1i\api_base = \"$OPENAI_API_BASE\"" ./.streamlit/secrets.toml
+    fi
 fi
 streamlit run app.py --server.port=8501 --server.enableCORS false --server.enableXsrfProtection false

--- a/helper.py
+++ b/helper.py
@@ -12,8 +12,7 @@ from text_toolkit import text_toolkit
 
 def get_history_chats(path: str) -> list:
     if "apikey" in st.secrets:
-        if not os.path.exists(path):
-            os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
         files = [f for f in os.listdir(f'./{path}') if f.endswith('.json')]
         files_with_time = [(f, os.stat(f'./{path}/' + f).st_ctime) for f in files]
         sorted_files = sorted(files_with_time, key=lambda x: x[1], reverse=True)


### PR DESCRIPTION
1. 新增配置项openai.api_base，借助https://github.com/beidongjiedeguang/openai-forward 可以实现免科学上网访问openai接口；
2. 提供镜像脚本，和jenkins的pipeline文件，可以制作镜像